### PR TITLE
Change license in setup.py to SPDX identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     classifiers=[],
     description='pytorch training tools',
     keywords=['basenet'],
-    license='ALV2',
+    license='Apache-2.0',
     packages=find_packages(),
     version="0.0.0"
 )


### PR DESCRIPTION
Apologies for being pedantic, but since I was on a roll clarifying licenses in my own org :sweat_smile:

This changes "ALV2" to the "official" (as per [spdx](https://spdx.org/licenses/Apache-2.0.html)) identifier for Apache License 2.0 (which I assume you meant? There is no license file, but "ALV2" is usually Apache?)